### PR TITLE
Fix warning options

### DIFF
--- a/lawvere.cabal
+++ b/lawvere.cabal
@@ -131,6 +131,8 @@ library
     , text
     , transformers
   default-language: Haskell2010
+  if impl(ghc >= 9.8)
+    ghc-options: -Wno-missing-role-annotations
 
 executable bill
   main-is: Main.hs
@@ -199,6 +201,8 @@ executable bill
     , text
     , transformers
   default-language: Haskell2010
+  if impl(ghc >= 9.8)
+    ghc-options: -Wno-missing-role-annotations
 
 test-suite lawvere-test
   type: exitcode-stdio-1.0
@@ -271,4 +275,6 @@ test-suite lawvere-test
     , text
     , transformers
   default-language: Haskell2010
+  if impl(ghc >= 9.8)
+    ghc-options: -Wno-missing-role-annotations
   build-tool-depends: hspec-discover:hspec-discover == 2.*

--- a/package.yaml
+++ b/package.yaml
@@ -116,6 +116,7 @@ ghc-options:
   - -Weverything
   - -Werror
   - -Wno-missing-exported-signatures # missing-exported-signatures turns off the more strict -Wmissing-signatures.
+  - -Wno-missing-kind-signatures
   - -Wno-missing-import-lists # Requires explicit imports of _every_ function (e.g. ‘$’); too strict
   - -Wno-missed-specialisations # When GHC can’t specialize a polymorphic function.
   - -Wno-all-missed-specialisations # See missed-specialisations

--- a/package.yaml
+++ b/package.yaml
@@ -128,3 +128,7 @@ ghc-options:
   - -Wno-missing-safe-haskell-mode
   - -Wno-prepositive-qualified-module
   - -Wno-unused-packages
+
+when:
+  - condition: impl(ghc >= 9.8)
+    ghc-options: -Wno-missing-role-annotations


### PR DESCRIPTION

This PR fixes two problems:

- 8f142381e6112bf14e320a7c8aceea29fd1b220f added `-Wno-missing-kind-signatures` to `lawvere.cabal` but not to `package.yaml`
- Compilation error on GHC >= 9.8 due to `missing-role-annotations` warnings and `-Werror`

There are still divergence between `lawvere.cabal` and `package.yaml`, namely GHC options `-threaded -rtsopts -with-rtsopts=-N`, but this PR does not fix the problem.