### PR TITLE
Fix exception handling in Main.hs

### DIFF
--- a/bill/Main.hs
+++ b/bill/Main.hs
@@ -148,12 +148,10 @@ repl warnings filepath_ = do
               loop
             Right expr -> do
               pr <- use #prog
-              let exec = Right <$> eval (Rec mempty) pr expr
+              let exec = Right <$> (evaluate =<< renderTerm =<< eval (Rec mempty) pr expr)
               res <- liftIO $ catch exec $ \(FatalError err) -> pure (Left ("ERROR: " <> err))
               case res of
-                Right v -> do
-                  out <- liftIO (renderTerm v)
-                  Repl $ outputStrLn (toS out)
+                Right out -> Repl $ outputStrLn (toS out)
                 Left err -> Repl $ outputStrLn (toS err)
               loop
 


### PR DESCRIPTION
I noticed that exceptions are sometimes caught correctly, while other times the interpreter simply terminates without catching them.

For example, in the following case, an exception is caught :
```
> (identity * identity + 1)
ERROR: bad scalar bin fn
```

On the other hand, in the following case, an exception goes unhandled, and the interpreter terminates:
```
> 42 identity + identity
bill: FatalError {fatalErrorMessage = "bad scalar bin fn"}
HasCallStack backtrace:
  bracket, called at libraries/haskeline/System/Console/Haskeline/InputT.hs:157:33 in haskeline-0.8.2.1-bd70:System.Console.Haskeline.InputT
```

This happens because the result of `eval` may contain unevaluated thunks that throw exceptions. To handle those exceptions properly, it is necessary to evaluate the result to the normal form under `catch`.